### PR TITLE
Fix torchvision compatibility in evaluation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,5 @@ cd UGATIT-pytorch
 
 pip install -r requirements.txt
 ```
+
+The included `eval.py` script automatically detects the torchvision API version. It uses `Inception_V3_Weights` when available and falls back to `pretrained=True` for older releases.

--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,31 @@
+import torch
+from torchvision import models
+
+# Provide a custom Identity for older PyTorch versions
+if hasattr(torch.nn, "Identity"):
+    Identity = torch.nn.Identity
+else:
+    class Identity(torch.nn.Module):
+        def forward(self, x):
+            return x
+
+
+def load_inception():
+    """Load torchvision Inception V3 with feature outputs.
+
+    The loader works with both old and new torchvision versions.
+    """
+    if hasattr(models, "Inception_V3_Weights"):
+        weights = models.Inception_V3_Weights.DEFAULT
+        inception = models.inception_v3(weights=weights)
+    else:
+        inception = models.inception_v3(pretrained=True)
+    inception.fc = Identity()
+    inception.eval()
+    return inception
+
+
+if __name__ == "__main__":
+    # Smoke test for manual execution
+    net = load_inception()
+    print("Loaded Inception V3")


### PR DESCRIPTION
## Summary
- add `eval.py` with compatibility helpers
- detect new torchvision weights in `load_inception`
- offer a custom `Identity` for older PyTorch
- document that eval script works with old and new torchvision

## Testing
- `python -m py_compile eval.py`

------
https://chatgpt.com/codex/tasks/task_e_685bae9f01a0832ba8af4d08ebe86475