### PR TITLE
Improve checkpoint error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The results of the paper came from the **Tensorflow code**
 ```
 > python main.py --dataset selfie2anime --phase test
 ```
+* Use `--resume_iter N` to load a specific checkpoint during testing.
 
 ## Architecture
 <div align="center">

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -449,15 +449,24 @@ class UGATIT(object) :
 
     def test(self):
         if self.resume_iter > 0:
-            checkpoint_path = os.path.join(self.result_dir, self.dataset, 'model',
-                                           self.dataset + '_params_%07d.pt' % self.resume_iter)
+            checkpoint_path = os.path.join(
+                self.result_dir,
+                self.dataset,
+                'model',
+                self.dataset + '_params_%07d.pt' % self.resume_iter,
+            )
             if os.path.exists(checkpoint_path):
-                self.load(os.path.join(self.result_dir, self.dataset, 'model'), self.resume_iter)
+                self.load(
+                    os.path.join(self.result_dir, self.dataset, 'model'),
+                    self.resume_iter,
+                )
                 print(" [*] Load SUCCESS")
                 iter = self.resume_iter
             else:
-                print(" [*] Load FAILURE")
-                return
+                raise FileNotFoundError(
+                    f'Checkpoint file not found: {checkpoint_path}. '
+                    'Ensure that resume_iter matches a saved iteration.'
+                )
         else:
             model_list = glob(os.path.join(self.result_dir, self.dataset, 'model', '*.pt'))
             if not len(model_list) == 0:

--- a/main.py
+++ b/main.py
@@ -98,7 +98,11 @@ def main():
         print(" [*] Training finished!")
 
     if args.phase == 'test' :
-        gan.test()
+        try:
+            gan.test()
+        except FileNotFoundError as e:
+            print(f'Error: {e}')
+            return
         print(" [*] Test finished!")
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- raise `FileNotFoundError` if `--resume_iter` checkpoint is missing
- print the error in `main.py` instead of claiming success
- document `--resume_iter` usage in README

## Testing
- `python -m py_compile UGATIT.py main.py eval.py dataset.py networks.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686c66259084832ba40acb687092e127