### PR TITLE
Remove unused style diversity and discriminator ratio options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,11 @@ below.
 > python main.py --dataset selfie2anime
 ```
 * If the memory of gpu is **not sufficient**, set `--light` to True
-* Enable style diversity with `--use_ds` (see `--style_dim` and `--ds_weight`)
 * Save memory with `--use_checkpoint` for gradient checkpointing
 * To train with a rectangular resolution, set `--aspect_ratio <width/height>`.
   The resulting width `img_size * aspect_ratio` must be divisible by 4.
   For example, a 1:2.3 ratio is approximated with `--aspect_ratio 0.44` when
   using the default `--img_size 256`.
-* Adjust global vs. local discriminator losses with `--global_dis_ratio <0~1>`.
-  The local ratio is `1 - global_dis_ratio`.
 
 ### Test
 ```
@@ -115,8 +112,6 @@ below.
 ## 🛠️ Key Modifications
 
 * `--aspect_ratio` option for non-square training resolutions
-* `--global_dis_ratio` to balance global and local discriminators
-* Optional style diversity via `--use_ds`, `--style_dim`, and `--ds_weight`
 * Gradient checkpointing via `--use_checkpoint`
 * Optional center cropping via `--center_crop` to keep aspect ratio without padding
 

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -43,12 +43,6 @@ class UGATIT(object) :
         self.cycle_weight = args.cycle_weight
         self.identity_weight = args.identity_weight
         self.cam_weight = args.cam_weight
-        self.global_dis_ratio = args.global_dis_ratio
-        self.local_dis_ratio = 1.0 - self.global_dis_ratio
-
-        self.use_ds = args.use_ds
-        self.style_dim = args.style_dim
-        self.ds_weight = args.ds_weight
 
         """ Generator """
         self.n_res = args.n_res
@@ -100,11 +94,6 @@ class UGATIT(object) :
         print("# cycle_weight : ", self.cycle_weight)
         print("# identity_weight : ", self.identity_weight)
         print("# cam_weight : ", self.cam_weight)
-        print("# global_dis_ratio : ", self.global_dis_ratio)
-        print("# local_dis_ratio : ", self.local_dis_ratio)
-        print("# use_ds : ", self.use_ds)
-        print("# style_dim : ", self.style_dim)
-        print("# ds_weight : ", self.ds_weight)
 
 
 
@@ -156,12 +145,10 @@ class UGATIT(object) :
         """ Define Generator, Discriminator """
         self.genA2B = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
-                                      light=self.light, style_dim=self.style_dim,
-                                      use_ds=self.use_ds).to(self.device)
+                                      light=self.light).to(self.device)
         self.genB2A = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
-                                      light=self.light, style_dim=self.style_dim,
-                                      use_ds=self.use_ds).to(self.device)
+                                      light=self.light).to(self.device)
         self.disGA = Discriminator(input_nc=3, ndf=self.ch, n_layers=7).to(self.device)
         self.disGB = Discriminator(input_nc=3, ndf=self.ch, n_layers=7).to(self.device)
         self.disLA = Discriminator(input_nc=3, ndf=self.ch, n_layers=5).to(self.device)
@@ -244,12 +231,10 @@ class UGATIT(object) :
             D_ad_loss_LB = self.MSE_loss(real_LB_logit, torch.ones_like(real_LB_logit).to(self.device)) + self.MSE_loss(fake_LB_logit, torch.zeros_like(fake_LB_logit).to(self.device))
             D_ad_cam_loss_LB = self.MSE_loss(real_LB_cam_logit, torch.ones_like(real_LB_cam_logit).to(self.device)) + self.MSE_loss(fake_LB_cam_logit, torch.zeros_like(fake_LB_cam_logit).to(self.device))
 
-            D_loss_A = self.adv_weight * (
-                self.global_dis_ratio * (D_ad_loss_GA + D_ad_cam_loss_GA) +
-                self.local_dis_ratio * (D_ad_loss_LA + D_ad_cam_loss_LA))
-            D_loss_B = self.adv_weight * (
-                self.global_dis_ratio * (D_ad_loss_GB + D_ad_cam_loss_GB) +
-                self.local_dis_ratio * (D_ad_loss_LB + D_ad_cam_loss_LB))
+            D_loss_A = self.adv_weight * 0.5 * (
+                D_ad_loss_GA + D_ad_cam_loss_GA + D_ad_loss_LA + D_ad_cam_loss_LA)
+            D_loss_B = self.adv_weight * 0.5 * (
+                D_ad_loss_GB + D_ad_cam_loss_GB + D_ad_loss_LB + D_ad_cam_loss_LB)
 
             Discriminator_loss = D_loss_A + D_loss_B
             if torch.isnan(Discriminator_loss):
@@ -292,34 +277,18 @@ class UGATIT(object) :
             G_cam_loss_A = self.BCE_loss(fake_B2A_cam_logit, torch.ones_like(fake_B2A_cam_logit).to(self.device)) + self.BCE_loss(fake_A2A_cam_logit, torch.zeros_like(fake_A2A_cam_logit).to(self.device))
             G_cam_loss_B = self.BCE_loss(fake_A2B_cam_logit, torch.ones_like(fake_A2B_cam_logit).to(self.device)) + self.BCE_loss(fake_B2B_cam_logit, torch.zeros_like(fake_B2B_cam_logit).to(self.device))
 
-            if self.use_ds and self.ds_weight > 0:
-                # Diversity sensitive loss
-                z_a1 = torch.randn(real_A.size(0), self.style_dim, device=self.device)
-                z_a2 = torch.randn(real_A.size(0), self.style_dim, device=self.device)
-                ds_A1, _, _ = self._call(self.genA2B, real_A, z_a1)
-                ds_A2, _, _ = self._call(self.genA2B, real_A, z_a2)
-                z_b1 = torch.randn(real_B.size(0), self.style_dim, device=self.device)
-                z_b2 = torch.randn(real_B.size(0), self.style_dim, device=self.device)
-                ds_B1, _, _ = self._call(self.genB2A, real_B, z_b1)
-                ds_B2, _, _ = self._call(self.genB2A, real_B, z_b2)
-                DS_loss = -(self.L1_loss(ds_A1, ds_A2.detach()) + self.L1_loss(ds_B1, ds_B2.detach()))
-            else:
-                DS_loss = torch.tensor(0.0, device=self.device)
-
-            G_loss_A = self.adv_weight * (
-                self.global_dis_ratio * (G_ad_loss_GA + G_ad_cam_loss_GA) +
-                self.local_dis_ratio * (G_ad_loss_LA + G_ad_cam_loss_LA)) \
+            G_loss_A = self.adv_weight * 0.5 * (
+                G_ad_loss_GA + G_ad_cam_loss_GA + G_ad_loss_LA + G_ad_cam_loss_LA) \
                 + self.cycle_weight * G_recon_loss_A \
                 + self.identity_weight * G_identity_loss_A \
                 + self.cam_weight * G_cam_loss_A
-            G_loss_B = self.adv_weight * (
-                self.global_dis_ratio * (G_ad_loss_GB + G_ad_cam_loss_GB) +
-                self.local_dis_ratio * (G_ad_loss_LB + G_ad_cam_loss_LB)) \
+            G_loss_B = self.adv_weight * 0.5 * (
+                G_ad_loss_GB + G_ad_cam_loss_GB + G_ad_loss_LB + G_ad_cam_loss_LB) \
                 + self.cycle_weight * G_recon_loss_B \
                 + self.identity_weight * G_identity_loss_B \
                 + self.cam_weight * G_cam_loss_B
 
-            Generator_loss = G_loss_A + G_loss_B + self.ds_weight * DS_loss
+            Generator_loss = G_loss_A + G_loss_B
             if torch.isnan(Generator_loss):
                 print('Warning: generator loss is NaN; skipping update')
             else:

--- a/main.py
+++ b/main.py
@@ -23,13 +23,6 @@ def parse_args():
     parser.add_argument('--cycle_weight', type=int, default=10, help='Weight for Cycle')
     parser.add_argument('--identity_weight', type=int, default=10, help='Weight for Identity')
     parser.add_argument('--cam_weight', type=int, default=1000, help='Weight for CAM')
-    parser.add_argument('--global_dis_ratio', type=float, default=0.5,
-                        help='Ratio of global discriminator loss (0~1)')
-
-    parser.add_argument('--use_ds', type=str2bool, default=False,
-                        help='enable style diversity with random style vectors')
-    parser.add_argument('--style_dim', type=int, default=8, help='dimension of style vector')
-    parser.add_argument('--ds_weight', type=float, default=1.0, help='diversity sensitive loss weight')
 
     parser.add_argument('--ch', type=int, default=64, help='base channel number per layer')
     parser.add_argument('--n_res', type=int, default=4, help='The number of resblock')
@@ -73,12 +66,8 @@ def check_args(args):
         assert args.batch_size >= 1
     except:
         print('batch size must be larger than or equal to one')
-    if not 0.0 <= args.global_dis_ratio <= 1.0:
-        raise ValueError('global_dis_ratio must be between 0 and 1')
     if args.img_w % 4 != 0:
         raise ValueError('img_size * aspect_ratio must be divisible by 4')
-    if args.use_ds and args.style_dim <= 0:
-        raise ValueError('style_dim must be positive when use_ds is enabled')
     return args
 
 """main"""


### PR DESCRIPTION
## Summary
- drop style diversity-related code and flags
- remove global/local discriminator ratio option and use fixed equal weighting
- update documentation accordingly

## Testing
- `python -m py_compile main.py UGATIT.py networks.py dataset.py utils.py eval.py preprocess_a.py UGATIT.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --quiet` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c971a9a88322bd9e927c5ee86922