### PR TITLE
feat: add style-conditioned SPADE AdaLIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ below.
 * Gradient checkpointing via `--use_checkpoint`
 * Optional center cropping via `--center_crop` to keep aspect ratio without padding
 * SPADE-AdaLIN style conditioning (`--use_spade_adalin`, `--style_nc`, `--lambda_style`,
-  `--lambda_lowpass`, `--fg_bg_cycle_ratio`) using a random domain B reference each step
+  `--lambda_lowpass`, `--fg_bg_cycle_ratio`) that splits a random domain B reference into
+  CAM-based foreground/background style codes
 
 ## 🛠️ Local Setup (for forked repo by @suguk1052)
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ below.
 * If the memory of gpu is **not sufficient**, set `--light` to True
 * Enable style diversity with `--use_ds` (see `--style_dim` and `--ds_weight`)
 * Inject reference-domain style and CAM-weighted losses with `--use_spade_adalin`
-  (tune `--style_nc`, `--lambda_style`, `--lambda_lowpass`, `--lambda_highpass`,
-  `--fg_bg_cycle_ratio`)
+  (tune `--style_nc`, `--lambda_style`, `--lambda_lowpass`, `--fg_bg_cycle_ratio`)
 * Save memory with `--use_checkpoint` for gradient checkpointing
 * To train with a rectangular resolution, set `--aspect_ratio <width/height>`.
   The resulting width `img_size * aspect_ratio` must be divisible by 4.
@@ -123,9 +122,9 @@ below.
 * Gradient checkpointing via `--use_checkpoint`
 * Optional center cropping via `--center_crop` to keep aspect ratio without padding
 * SPADE-AdaLIN style conditioning (`--use_spade_adalin`, `--style_nc`, `--lambda_style`,
-  `--lambda_lowpass`, `--lambda_highpass`, `--fg_bg_cycle_ratio`) that splits a random
+  `--lambda_lowpass`, `--fg_bg_cycle_ratio`) that splits a random
   domain B reference into CAM-based foreground/background style codes, copies the source
-  background during A→B→A cycles, penalizes background high-frequency mismatch, weights
+  background during A→B→A cycles, enforces background low-frequency tone consistency, weights
   cycle/identity losses with the source-domain masks, and limits skip connections to the
   foreground to curb background bleeding
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ below.
 * If the memory of gpu is **not sufficient**, set `--light` to True
 * Enable style diversity with `--use_ds` (see `--style_dim` and `--ds_weight`)
 * Inject reference-domain style and CAM-weighted losses with `--use_spade_adalin`
-  (tune `--style_nc`, `--lambda_style`, `--lambda_lowpass`, `--fg_bg_cycle_ratio`)
+  (tune `--style_nc`, `--lambda_style`, `--lambda_lowpass`, `--lambda_highpass`,
+  `--fg_bg_cycle_ratio`)
 * Save memory with `--use_checkpoint` for gradient checkpointing
 * To train with a rectangular resolution, set `--aspect_ratio <width/height>`.
   The resulting width `img_size * aspect_ratio` must be divisible by 4.
@@ -122,10 +123,11 @@ below.
 * Gradient checkpointing via `--use_checkpoint`
 * Optional center cropping via `--center_crop` to keep aspect ratio without padding
 * SPADE-AdaLIN style conditioning (`--use_spade_adalin`, `--style_nc`, `--lambda_style`,
-  `--lambda_lowpass`, `--fg_bg_cycle_ratio`) that splits a random domain B reference into
-  CAM-based foreground/background style codes, weights cycle/identity losses with the
-  source-domain masks, and limits skip connections to the foreground to curb background
-  bleeding
+  `--lambda_lowpass`, `--lambda_highpass`, `--fg_bg_cycle_ratio`) that splits a random
+  domain B reference into CAM-based foreground/background style codes, copies the source
+  background during A→B→A cycles, penalizes background high-frequency mismatch, weights
+  cycle/identity losses with the source-domain masks, and limits skip connections to the
+  foreground to curb background bleeding
 
 ## 🛠️ Local Setup (for forked repo by @suguk1052)
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ below.
 * Optional center cropping via `--center_crop` to keep aspect ratio without padding
 * SPADE-AdaLIN style conditioning (`--use_spade_adalin`, `--style_nc`, `--lambda_style`,
   `--lambda_lowpass`, `--fg_bg_cycle_ratio`) that splits a random domain B reference into
-  CAM-based foreground/background style codes
+  CAM-based foreground/background style codes, weights cycle/identity losses with the
+  source-domain masks, and limits skip connections to the foreground to curb background
+  bleeding
 
 ## 🛠️ Local Setup (for forked repo by @suguk1052)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ below.
 ```
 * If the memory of gpu is **not sufficient**, set `--light` to True
 * Enable style diversity with `--use_ds` (see `--style_dim` and `--ds_weight`)
+* Inject reference-domain style and CAM-weighted losses with `--use_spade_adalin`
+  (tune `--style_nc`, `--lambda_style`, `--lambda_lowpass`, `--fg_bg_cycle_ratio`)
 * Save memory with `--use_checkpoint` for gradient checkpointing
 * To train with a rectangular resolution, set `--aspect_ratio <width/height>`.
   The resulting width `img_size * aspect_ratio` must be divisible by 4.
@@ -119,6 +121,8 @@ below.
 * Optional style diversity via `--use_ds`, `--style_dim`, and `--ds_weight`
 * Gradient checkpointing via `--use_checkpoint`
 * Optional center cropping via `--center_crop` to keep aspect ratio without padding
+* SPADE-AdaLIN style conditioning (`--use_spade_adalin`, `--style_nc`, `--lambda_style`,
+  `--lambda_lowpass`, `--fg_bg_cycle_ratio`) using a random domain B reference each step
 
 ## 🛠️ Local Setup (for forked repo by @suguk1052)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ below.
 * If the memory of gpu is **not sufficient**, set `--light` to True
 * Enable style diversity with `--use_ds` (see `--style_dim` and `--ds_weight`)
 * Inject reference-domain style and CAM-weighted losses with `--use_spade_adalin`
-  (tune `--style_nc`, `--lambda_style`, `--lambda_lowpass`, `--fg_bg_cycle_ratio`)
+  (tune `--style_nc`, `--lambda_style`, `--lambda_lowpass`)
 * Save memory with `--use_checkpoint` for gradient checkpointing
 * To train with a rectangular resolution, set `--aspect_ratio <width/height>`.
   The resulting width `img_size * aspect_ratio` must be divisible by 4.
@@ -122,10 +122,10 @@ below.
 * Gradient checkpointing via `--use_checkpoint`
 * Optional center cropping via `--center_crop` to keep aspect ratio without padding
 * SPADE-AdaLIN style conditioning (`--use_spade_adalin`, `--style_nc`, `--lambda_style`,
-  `--lambda_lowpass`, `--fg_bg_cycle_ratio`) that splits a random
-  domain B reference into CAM-based foreground/background style codes, copies the source
-  background during A→B→A cycles, enforces background low-frequency tone consistency, weights
-  cycle/identity losses with the source-domain masks, and limits skip connections to the
+  `--lambda_lowpass`) that splits a random domain B reference into CAM-based
+  foreground/background style codes, copies the source background during A→B→A
+  cycles, enforces background low-frequency tone consistency, weights cycle and
+  identity losses with source-domain masks, and limits skip connections to the
   foreground to curb background bleeding
 
 ## 🛠️ Local Setup (for forked repo by @suguk1052)

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -252,7 +252,8 @@ class UGATIT(object) :
 
             # Update D
             self.D_optim.zero_grad()
-            fake_A2B, _, _ = self._call(self.genA2B, real_A, None, s_ref)
+            s_ref_detach = s_ref.detach() if s_ref is not None else None
+            fake_A2B, _, _ = self._call(self.genA2B, real_A, None, s_ref_detach)
             fake_B2A, _, _ = self._call(self.genB2A, real_B)
 
             real_GA_logit, real_GA_cam_logit, _ = self._call(self.disGA, real_A)
@@ -290,6 +291,8 @@ class UGATIT(object) :
 
             # Update G
             self.G_optim.zero_grad()
+            if self.use_spade_adalin:
+                s_ref = self.style_enc_B(b_ref)
             fake_A2B, fake_A2B_cam_logit, fake_A2B_heatmap = self._call(self.genA2B, real_A, None, s_ref)
             fake_B2A, fake_B2A_cam_logit, fake_B2A_heatmap = self._call(self.genB2A, real_B)
 

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -316,8 +316,10 @@ class UGATIT(object) :
 
             if self.use_spade_adalin:
                 m_fg_A = norm_01(fake_A2B_heatmap.detach())
+                m_fg_A = F.interpolate(m_fg_A, size=real_A.size()[2:], mode='bilinear', align_corners=False)
                 w_fg_A, w_bg_A = m_fg_A, 1 - m_fg_A
                 m_fg_B = norm_01(fake_B2A_heatmap.detach())
+                m_fg_B = F.interpolate(m_fg_B, size=real_B.size()[2:], mode='bilinear', align_corners=False)
                 w_fg_B, w_bg_B = m_fg_B, 1 - m_fg_B
 
                 recon_A_fg = torch.mean(torch.abs(w_fg_A * (fake_A2B2A - real_A)))

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -415,14 +415,21 @@ class UGATIT(object) :
                             real_B, _ = trainB_iter.next()
                         real_A, real_B = real_A.to(self.device), real_B.to(self.device)
 
-                        fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A)
-                        fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
-
-                        fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
-                        fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A)
-
-                        fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
-                        fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B)
+                        if self.use_spade_adalin:
+                            s_ref = self.style_enc_B(real_B)
+                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A, s_ref)
+                            fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
+                            fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
+                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A, s_ref)
+                            fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
+                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B, s_ref)
+                        else:
+                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A)
+                            fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
+                            fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
+                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A)
+                            fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
+                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B)
 
                         A2B = np.concatenate((A2B, np.concatenate((RGB2BGR(tensor2numpy(denorm(real_A[0]))),
                                                                    cam(tensor2numpy(fake_A2A_heatmap[0]), (self.img_size, self.img_w)),
@@ -454,14 +461,21 @@ class UGATIT(object) :
                             real_B, _ = testB_iter.next()
                         real_A, real_B = real_A.to(self.device), real_B.to(self.device)
 
-                        fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A)
-                        fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
-
-                        fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
-                        fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A)
-
-                        fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
-                        fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B)
+                        if self.use_spade_adalin:
+                            s_ref = self.style_enc_B(real_B)
+                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A, s_ref)
+                            fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
+                            fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
+                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A, s_ref)
+                            fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
+                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B, s_ref)
+                        else:
+                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A)
+                            fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
+                            fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
+                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A)
+                            fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
+                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B)
 
                         A2B = np.concatenate((A2B, np.concatenate((RGB2BGR(tensor2numpy(denorm(real_A[0]))),
                                                                    cam(tensor2numpy(fake_A2A_heatmap[0]), (self.img_size, self.img_w)),
@@ -557,7 +571,11 @@ class UGATIT(object) :
             for n, (real_A, _) in enumerate(self.testA_loader):
                 real_A = real_A.to(self.device)
 
-                fake_A2B, _, _ = self._call(self.genA2B, real_A)
+                if self.use_spade_adalin:
+                    s_zero = torch.zeros(real_A.size(0), self.style_nc, device=self.device)
+                    fake_A2B, _, _ = self._call(self.genA2B, real_A, None, s_zero)
+                else:
+                    fake_A2B, _, _ = self._call(self.genA2B, real_A)
 
                 out_A2B = RGB2BGR(tensor2numpy(denorm(fake_A2B[0])))
 

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -417,12 +417,12 @@ class UGATIT(object) :
 
                         if self.use_spade_adalin:
                             s_ref = self.style_enc_B(real_B)
-                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A, s_ref)
+                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A, None, s_ref)
                             fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
                             fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
-                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A, s_ref)
+                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A, None, s_ref)
                             fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
-                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B, s_ref)
+                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B, None, s_ref)
                         else:
                             fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A)
                             fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
@@ -463,12 +463,12 @@ class UGATIT(object) :
 
                         if self.use_spade_adalin:
                             s_ref = self.style_enc_B(real_B)
-                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A, s_ref)
+                            fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A, None, s_ref)
                             fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)
                             fake_A2B2A, _, fake_A2B2A_heatmap = self.genB2A(fake_A2B)
-                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A, s_ref)
+                            fake_B2A2B, _, fake_B2A2B_heatmap = self.genA2B(fake_B2A, None, s_ref)
                             fake_A2A, _, fake_A2A_heatmap = self.genB2A(real_A)
-                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B, s_ref)
+                            fake_B2B, _, fake_B2B_heatmap = self.genA2B(real_B, None, s_ref)
                         else:
                             fake_A2B, _, fake_A2B_heatmap = self.genA2B(real_A)
                             fake_B2A, _, fake_B2A_heatmap = self.genB2A(real_B)

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -6,6 +6,7 @@ from networks import *
 from utils import *
 from utils import ResizeCenterCrop
 import torch
+import torch.nn.functional as F
 try:
     import torch.utils.checkpoint as checkpoint
     _CHECKPOINT_AVAILABLE = True
@@ -49,6 +50,12 @@ class UGATIT(object) :
         self.use_ds = args.use_ds
         self.style_dim = args.style_dim
         self.ds_weight = args.ds_weight
+
+        self.use_spade_adalin = args.use_spade_adalin
+        self.style_nc = args.style_nc
+        self.lambda_style = args.lambda_style
+        self.lambda_lowpass = args.lambda_lowpass
+        self.fg_bg_ratio = args.fg_bg_cycle_ratio
 
         """ Generator """
         self.n_res = args.n_res
@@ -105,6 +112,11 @@ class UGATIT(object) :
         print("# use_ds : ", self.use_ds)
         print("# style_dim : ", self.style_dim)
         print("# ds_weight : ", self.ds_weight)
+        print("# use_spade_adalin : ", self.use_spade_adalin)
+        print("# style_nc : ", self.style_nc)
+        print("# lambda_style : ", self.lambda_style)
+        print("# lambda_lowpass : ", self.lambda_lowpass)
+        print("# fg_bg_cycle_ratio : ", self.fg_bg_ratio)
 
 
 
@@ -157,7 +169,9 @@ class UGATIT(object) :
         self.genA2B = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
                                       light=self.light, style_dim=self.style_dim,
-                                      use_ds=self.use_ds).to(self.device)
+                                      use_ds=self.use_ds,
+                                      use_spade_adalin=self.use_spade_adalin,
+                                      style_nc=self.style_nc).to(self.device)
         self.genB2A = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
                                       light=self.light, style_dim=self.style_dim,
@@ -173,7 +187,15 @@ class UGATIT(object) :
         self.BCE_loss = nn.BCEWithLogitsLoss().to(self.device)
 
         """ Trainer """
-        self.G_optim = torch.optim.Adam(itertools.chain(self.genA2B.parameters(), self.genB2A.parameters()), lr=self.lr, betas=(0.5, 0.999), weight_decay=self.weight_decay)
+        if self.use_spade_adalin:
+            self.style_enc_B = StyleEncoder(in_nc=3, out_dim=self.style_nc).to(self.device)
+            g_params = itertools.chain(self.genA2B.parameters(), self.genB2A.parameters(),
+                                       self.style_enc_B.parameters())
+        else:
+            self.style_enc_B = None
+            g_params = itertools.chain(self.genA2B.parameters(), self.genB2A.parameters())
+
+        self.G_optim = torch.optim.Adam(g_params, lr=self.lr, betas=(0.5, 0.999), weight_decay=self.weight_decay)
         self.D_optim = torch.optim.Adam(itertools.chain(self.disGA.parameters(), self.disGB.parameters(), self.disLA.parameters(), self.disLB.parameters()), lr=self.lr, betas=(0.5, 0.999), weight_decay=self.weight_decay)
 
         """ Define Rho clipper to constraint the value of rho in AdaILN and ILN"""
@@ -199,6 +221,7 @@ class UGATIT(object) :
         start_time = time.time()
         trainA_iter = iter(self.trainA_loader)
         trainB_iter = iter(self.trainB_loader)
+        trainB_ref_iter = iter(self.trainB_loader)
         testA_iter = iter(self.testA_loader)
         testB_iter = iter(self.testB_loader)
         for step in range(start_iter, self.iteration + 1):
@@ -217,12 +240,19 @@ class UGATIT(object) :
             except:
                 trainB_iter = iter(self.trainB_loader)
                 real_B, _ = trainB_iter.next()
+            try:
+                b_ref, _ = trainB_ref_iter.next()
+            except:
+                trainB_ref_iter = iter(self.trainB_loader)
+                b_ref, _ = trainB_ref_iter.next()
 
             real_A, real_B = real_A.to(self.device), real_B.to(self.device)
+            b_ref = b_ref.to(self.device)
+            s_ref = self.style_enc_B(b_ref) if self.use_spade_adalin else None
 
             # Update D
             self.D_optim.zero_grad()
-            fake_A2B, _, _ = self._call(self.genA2B, real_A)
+            fake_A2B, _, _ = self._call(self.genA2B, real_A, None, s_ref)
             fake_B2A, _, _ = self._call(self.genB2A, real_B)
 
             real_GA_logit, real_GA_cam_logit, _ = self._call(self.disGA, real_A)
@@ -260,14 +290,15 @@ class UGATIT(object) :
 
             # Update G
             self.G_optim.zero_grad()
-            fake_A2B, fake_A2B_cam_logit, _ = self._call(self.genA2B, real_A)
-            fake_B2A, fake_B2A_cam_logit, _ = self._call(self.genB2A, real_B)
+            fake_A2B, fake_A2B_cam_logit, fake_A2B_heatmap = self._call(self.genA2B, real_A, None, s_ref)
+            fake_B2A, fake_B2A_cam_logit, fake_B2A_heatmap = self._call(self.genB2A, real_B)
 
             fake_A2B2A, _, _ = self._call(self.genB2A, fake_A2B)
-            fake_B2A2B, _, _ = self._call(self.genA2B, fake_B2A)
+            fake_B2A2B, _, _ = self._call(self.genA2B, fake_B2A, None, s_ref)
 
             fake_A2A, fake_A2A_cam_logit, _ = self._call(self.genB2A, real_A)
-            fake_B2B, fake_B2B_cam_logit, _ = self._call(self.genA2B, real_B)
+            s_real_B = self.style_enc_B(real_B) if self.use_spade_adalin else None
+            fake_B2B, fake_B2B_cam_logit, _ = self._call(self.genA2B, real_B, None, s_real_B)
 
             fake_GA_logit, fake_GA_cam_logit, _ = self._call(self.disGA, fake_B2A)
             fake_LA_logit, fake_LA_cam_logit, _ = self._call(self.disLA, fake_B2A)
@@ -283,11 +314,36 @@ class UGATIT(object) :
             G_ad_loss_LB = self.MSE_loss(fake_LB_logit, torch.ones_like(fake_LB_logit).to(self.device))
             G_ad_cam_loss_LB = self.MSE_loss(fake_LB_cam_logit, torch.ones_like(fake_LB_cam_logit).to(self.device))
 
-            G_recon_loss_A = self.L1_loss(fake_A2B2A, real_A)
-            G_recon_loss_B = self.L1_loss(fake_B2A2B, real_B)
+            if self.use_spade_adalin:
+                m_fg_A = norm_01(fake_A2B_heatmap.detach())
+                w_fg_A, w_bg_A = m_fg_A, 1 - m_fg_A
+                m_fg_B = norm_01(fake_B2A_heatmap.detach())
+                w_fg_B, w_bg_B = m_fg_B, 1 - m_fg_B
 
-            G_identity_loss_A = self.L1_loss(fake_A2A, real_A)
-            G_identity_loss_B = self.L1_loss(fake_B2B, real_B)
+                recon_A_fg = torch.mean(torch.abs(w_fg_A * (fake_A2B2A - real_A)))
+                recon_A_bg = torch.mean(torch.abs(w_bg_A * (fake_A2B2A - real_A))) * self.fg_bg_ratio
+                G_recon_loss_A = recon_A_fg + recon_A_bg
+                recon_B_fg = torch.mean(torch.abs(w_fg_B * (fake_B2A2B - real_B)))
+                recon_B_bg = torch.mean(torch.abs(w_bg_B * (fake_B2A2B - real_B))) * self.fg_bg_ratio
+                G_recon_loss_B = recon_B_fg + recon_B_bg
+
+                id_A_fg = torch.mean(torch.abs(w_fg_A * (fake_A2A - real_A)))
+                id_A_bg = torch.mean(torch.abs(w_bg_A * (fake_A2A - real_A))) * self.fg_bg_ratio
+                G_identity_loss_A = id_A_fg + id_A_bg
+                id_B_fg = torch.mean(torch.abs(w_fg_B * (fake_B2B - real_B)))
+                id_B_bg = torch.mean(torch.abs(w_bg_B * (fake_B2B - real_B))) * self.fg_bg_ratio
+                G_identity_loss_B = id_B_fg + id_B_bg
+
+                s_fake = self.style_enc_B(fake_A2B)
+                L_style = torch.mean(torch.abs(s_fake - s_ref))
+                L_lp = torch.mean(torch.abs(F.avg_pool2d(fake_A2B, 7, 1, 3) - F.avg_pool2d(b_ref, 7, 1, 3)))
+            else:
+                G_recon_loss_A = self.L1_loss(fake_A2B2A, real_A)
+                G_recon_loss_B = self.L1_loss(fake_B2A2B, real_B)
+                G_identity_loss_A = self.L1_loss(fake_A2A, real_A)
+                G_identity_loss_B = self.L1_loss(fake_B2B, real_B)
+                L_style = torch.tensor(0.0, device=self.device)
+                L_lp = torch.tensor(0.0, device=self.device)
 
             G_cam_loss_A = self.BCE_loss(fake_B2A_cam_logit, torch.ones_like(fake_B2A_cam_logit).to(self.device)) + self.BCE_loss(fake_A2A_cam_logit, torch.zeros_like(fake_A2A_cam_logit).to(self.device))
             G_cam_loss_B = self.BCE_loss(fake_A2B_cam_logit, torch.ones_like(fake_A2B_cam_logit).to(self.device)) + self.BCE_loss(fake_B2B_cam_logit, torch.zeros_like(fake_B2B_cam_logit).to(self.device))
@@ -319,7 +375,8 @@ class UGATIT(object) :
                 + self.identity_weight * G_identity_loss_B \
                 + self.cam_weight * G_cam_loss_B
 
-            Generator_loss = G_loss_A + G_loss_B + self.ds_weight * DS_loss
+            Generator_loss = G_loss_A + G_loss_B + self.ds_weight * DS_loss \
+                + self.lambda_style * L_style + self.lambda_lowpass * L_lp
             if torch.isnan(Generator_loss):
                 print('Warning: generator loss is NaN; skipping update')
             else:

--- a/main.py
+++ b/main.py
@@ -36,7 +36,6 @@ def parse_args():
     parser.add_argument('--style_nc', type=int, default=256, help='style code dimension')
     parser.add_argument('--lambda_style', type=float, default=1.0, help='style consistency loss weight')
     parser.add_argument('--lambda_lowpass', type=float, default=5.0, help='low-pass tone loss weight')
-    parser.add_argument('--lambda_highpass', type=float, default=1.0, help='high-pass texture loss weight')
     parser.add_argument('--fg_bg_cycle_ratio', type=float, default=0.2,
                         help='background weight ratio for cycle/identity losses')
 

--- a/main.py
+++ b/main.py
@@ -31,6 +31,14 @@ def parse_args():
     parser.add_argument('--style_dim', type=int, default=8, help='dimension of style vector')
     parser.add_argument('--ds_weight', type=float, default=1.0, help='diversity sensitive loss weight')
 
+    parser.add_argument('--use_spade_adalin', type=str2bool, default=False,
+                        help='enable SPADE-AdaLIN in generator')
+    parser.add_argument('--style_nc', type=int, default=256, help='style code dimension')
+    parser.add_argument('--lambda_style', type=float, default=1.0, help='style consistency loss weight')
+    parser.add_argument('--lambda_lowpass', type=float, default=5.0, help='low-pass tone loss weight')
+    parser.add_argument('--fg_bg_cycle_ratio', type=float, default=0.2,
+                        help='background weight ratio for cycle/identity losses')
+
     parser.add_argument('--ch', type=int, default=64, help='base channel number per layer')
     parser.add_argument('--n_res', type=int, default=4, help='The number of resblock')
     parser.add_argument('--n_dis', type=int, default=6, help='The number of discriminator layer')

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ def parse_args():
     parser.add_argument('--style_nc', type=int, default=256, help='style code dimension')
     parser.add_argument('--lambda_style', type=float, default=1.0, help='style consistency loss weight')
     parser.add_argument('--lambda_lowpass', type=float, default=5.0, help='low-pass tone loss weight')
+    parser.add_argument('--lambda_highpass', type=float, default=1.0, help='high-pass texture loss weight')
     parser.add_argument('--fg_bg_cycle_ratio', type=float, default=0.2,
                         help='background weight ratio for cycle/identity losses')
 

--- a/main.py
+++ b/main.py
@@ -36,8 +36,6 @@ def parse_args():
     parser.add_argument('--style_nc', type=int, default=256, help='style code dimension')
     parser.add_argument('--lambda_style', type=float, default=1.0, help='style consistency loss weight')
     parser.add_argument('--lambda_lowpass', type=float, default=5.0, help='low-pass tone loss weight')
-    parser.add_argument('--fg_bg_cycle_ratio', type=float, default=0.2,
-                        help='background weight ratio for cycle/identity losses')
 
     parser.add_argument('--ch', type=int, default=64, help='base channel number per layer')
     parser.add_argument('--n_res', type=int, default=4, help='The number of resblock')

--- a/networks.py
+++ b/networks.py
@@ -88,7 +88,8 @@ class ResnetSPADEAdaLINBlock(nn.Module):
         out = self.pad2(out)
         out = self.conv2(out)
         out = self.norm2(out, cond)
-        return out + x
+        mask = cond[:, -1:, :, :]
+        return out + x * mask
 
 
 class ResnetGenerator(nn.Module):

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,7 @@ import torch
 import numpy as np
 from PIL import Image, ImageOps
 from torchvision.transforms import functional as TF
+import torch.nn.functional as F
 
 def load_test_data(image_path, size=256):
     img = misc.imread(image_path, mode='RGB')
@@ -103,3 +104,12 @@ def norm_01(x: torch.Tensor) -> torch.Tensor:
     min_val = flat.min(dim=1)[0].view(b, 1, 1, 1)
     max_val = flat.max(dim=1)[0].view(b, 1, 1, 1)
     return (x - min_val) / (max_val - min_val + 1e-8)
+
+
+def high_pass(x: torch.Tensor) -> torch.Tensor:
+    """Simple Laplacian high-pass filter."""
+    kernel = torch.tensor([[0, -1, 0],
+                           [-1, 4, -1],
+                           [0, -1, 0]], dtype=x.dtype, device=x.device)
+    kernel = kernel.view(1, 1, 3, 3).repeat(x.size(1), 1, 1, 1)
+    return F.conv2d(x, kernel, padding=1, groups=x.size(1))

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,6 @@ import torch
 import numpy as np
 from PIL import Image, ImageOps
 from torchvision.transforms import functional as TF
-import torch.nn.functional as F
 
 def load_test_data(image_path, size=256):
     img = misc.imread(image_path, mode='RGB')
@@ -104,12 +103,3 @@ def norm_01(x: torch.Tensor) -> torch.Tensor:
     min_val = flat.min(dim=1)[0].view(b, 1, 1, 1)
     max_val = flat.max(dim=1)[0].view(b, 1, 1, 1)
     return (x - min_val) / (max_val - min_val + 1e-8)
-
-
-def high_pass(x: torch.Tensor) -> torch.Tensor:
-    """Simple Laplacian high-pass filter."""
-    kernel = torch.tensor([[0, -1, 0],
-                           [-1, 4, -1],
-                           [0, -1, 0]], dtype=x.dtype, device=x.device)
-    kernel = kernel.view(1, 1, 3, 3).repeat(x.size(1), 1, 1, 1)
-    return F.conv2d(x, kernel, padding=1, groups=x.size(1))

--- a/utils.py
+++ b/utils.py
@@ -94,3 +94,12 @@ class ResizeCenterCrop:
         bottom = top + target_h
         img = img.crop((left, top, right, bottom))
         return img
+
+
+def norm_01(x: torch.Tensor) -> torch.Tensor:
+    """Normalize tensor to [0,1] range per-sample."""
+    b = x.size(0)
+    flat = x.view(b, -1)
+    min_val = flat.min(dim=1)[0].view(b, 1, 1, 1)
+    max_val = flat.max(dim=1)[0].view(b, 1, 1, 1)
+    return (x - min_val) / (max_val - min_val + 1e-8)


### PR DESCRIPTION
## Summary
- add StyleEncoder and SPADE-AdaLIN blocks for foreground-aware style transfer
- weight cycle/identity losses with CAM mask and enforce style/low-pass consistency
- expose CLI flags for SPADE/AdaLIN and style losses

## Testing
- `python -m py_compile UGATIT.py main.py networks.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a67df37cec83229484593e639300c8