### PR TITLE
Allow custom test directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ below.
 * Use `--resume_iter N` to load a specific checkpoint during testing.
 * Generated images are stored under `results/YOUR_DATASET_NAME/test/A2B/` and
   `test/B2A/` using the original filenames from `testA` and `testB`.
+* Supply `--testA_dir PATH` (or `--testB_dir PATH`) to use external folders for
+  the A or B domain test images without copying them into the repository.
 
 ## Architecture
 <div align="center">
@@ -153,4 +155,6 @@ or `test/B2A/`. Each JSON also records how many real and fake images were
 used. The KID file contains both the raw `kid` value and `kid_x100` for
 convenience.
 You can also specify `--real_dir PATH` to override the directory of real
-images used as ground truth (by default it is `testB` or `testA`).
+images used as ground truth (by default it is `testB` or `testA`). Use
+`--fake_dir PATH` to evaluate results stored outside the default
+`results/DATASET/test/` hierarchy.

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -1,4 +1,5 @@
 import time, itertools
+import os
 from dataset import ImageFolder
 from torchvision import transforms
 from torch.utils.data import DataLoader
@@ -26,6 +27,8 @@ class UGATIT(object) :
 
         self.result_dir = args.result_dir
         self.dataset = args.dataset
+        self.testA_dir = args.testA_dir
+        self.testB_dir = args.testB_dir
 
         self.iteration = args.iteration
         self.decay_flag = args.decay_flag
@@ -146,8 +149,17 @@ class UGATIT(object) :
 
         self.trainA = ImageFolder(os.path.join('dataset', self.dataset, 'trainA'), train_transform)
         self.trainB = ImageFolder(os.path.join('dataset', self.dataset, 'trainB'), train_transform)
-        self.testA = ImageFolder(os.path.join('dataset', self.dataset, 'testA'), test_transform)
-        self.testB = ImageFolder(os.path.join('dataset', self.dataset, 'testB'), test_transform)
+
+        testA_root = self.testA_dir if self.testA_dir is not None else os.path.join('dataset', self.dataset, 'testA')
+        testB_root = self.testB_dir if self.testB_dir is not None else os.path.join('dataset', self.dataset, 'testB')
+
+        if not os.path.isdir(testA_root):
+            raise FileNotFoundError(f'Test A directory not found: {testA_root}')
+        if not os.path.isdir(testB_root):
+            raise FileNotFoundError(f'Test B directory not found: {testB_root}')
+
+        self.testA = ImageFolder(testA_root, test_transform)
+        self.testB = ImageFolder(testB_root, test_transform)
         self.trainA_loader = DataLoader(self.trainA, batch_size=self.batch_size, shuffle=True)
         self.trainB_loader = DataLoader(self.trainB, batch_size=self.batch_size, shuffle=True)
         self.testA_loader = DataLoader(self.testA, batch_size=1, shuffle=False)

--- a/eval.py
+++ b/eval.py
@@ -144,6 +144,8 @@ def main():
                         help='Optional directory of real images to use as ground truth')
     parser.add_argument('--result_dir', default='results',
                         help='Directory containing generated results')
+    parser.add_argument('--fake_dir', default=None,
+                        help='Optional directory of generated images; overrides result_dir/dataset/test')
     parser.add_argument('--num_samples', type=int, default=None,
                         help='Number of images to evaluate; defaults to using '
                              'all available images')
@@ -162,7 +164,11 @@ def main():
         )
     else:
         real_dir = args.real_dir
-    fake_dir = os.path.join(args.result_dir, args.dataset, 'test', args.direction)
+
+    if args.fake_dir is None:
+        fake_dir = os.path.join(args.result_dir, args.dataset, 'test', args.direction)
+    else:
+        fake_dir = args.fake_dir
 
     real_paths = list_image_files(real_dir)
     fake_paths = list_image_files(fake_dir)

--- a/main.py
+++ b/main.py
@@ -10,6 +10,10 @@ def parse_args():
     parser.add_argument('--phase', type=str, default='train', help='[train / test]')
     parser.add_argument('--light', type=str2bool, default=False, help='[U-GAT-IT full version / U-GAT-IT light version]')
     parser.add_argument('--dataset', type=str, default='YOUR_DATASET_NAME', help='dataset_name')
+    parser.add_argument('--testA_dir', type=str, default=None,
+                        help='Optional path to A-domain test images')
+    parser.add_argument('--testB_dir', type=str, default=None,
+                        help='Optional path to B-domain test images')
 
     parser.add_argument('--iteration', type=int, default=1000000, help='The number of training iterations')
     parser.add_argument('--batch_size', type=int, default=1, help='The size of batch size')


### PR DESCRIPTION
## Summary
- enable optional `--testA_dir` and `--testB_dir` to load test images from any folder
- add `--fake_dir` in eval.py to evaluate images saved outside the default results tree
- document new CLI options in README

## Testing
- `python -m py_compile main.py UGATIT.py eval.py`
- `pip install torch torchvision` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ed94d2388322939713d585fe9faa