### PR TITLE
Add optional cropping to preprocessing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,26 @@ The results of the paper came from the **Tensorflow code**
 
 If you need to crop and augment domain A images before training, place the
 original files under `preprocess_source/trainA` and `preprocess_source/testA`
-and run:
+and run the script once for each folder, for example:
 
 ```
-python preprocess_a.py --dataset_name YOUR_DATASET_NAME [--bottom]
+python preprocess_a.py --input_dir preprocess_source/trainA \
+                       --output_dir dataset/YOUR_DATASET_NAME/trainA
 ```
 
-Run this once before starting `main.py` to prepare domain A images.
+Add `--top` to keep the upper 40 % with a 35–45 % fade band or `--bottom` to
+retain the lower 30 % with a 65–75 % fade band. Without either flag the images
+are left uncropped.
 
-By default the script keeps only the top 40 % of each image, fading to neutral
-gray across the 35–45 % band using a Gaussian kernel. With the `--bottom` flag,
-it instead retains the bottom 30 %, fading the 65–75 % band. The resulting
-canvas undergoes random translations up to ±10 pixels and random rotations up to
-±10°, with any exposed regions filled with the same gray. The output is scaled
-to cover a 512×512 frame while keeping aspect ratio and cropped so the row at
-20 % (or 93 % when using `--bottom`) of the original height falls at the canvas
-center. Each processed file keeps the original base name and is written to
-`dataset/YOUR_DATASET_NAME/trainA` and `dataset/YOUR_DATASET_NAME/testA`. After
-running this preprocessing step you can proceed with the usual training command
-below.
+In all modes the canvas experiences random translations up to ±10 pixels and
+random rotations up to ±10°, with exposed regions filled in gray. After the
+translation step, an additional 50 px gray margin is appended to the side
+opposite the shift on both axes. When `--top` or `--bottom` is supplied, the
+resulting image is further scaled to cover a 512×512 frame and cropped so a
+reference band (20 % from the top when using `--top`, 93 % when using `--bottom`)
+lands at the canvas center. Each processed file keeps the original base name and
+is written to the specified output directory. After running this preprocessing
+step you can proceed with the usual training command below.
 
 ### Train
 ```

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ retain the lower 30 % with a 65–75 % fade band. Without either flag the im
 are left uncropped.
 
 In all modes the canvas experiences random translations up to ±10 pixels and
-random rotations up to ±10°, with exposed regions filled in gray. After the
-translation step, a gray margin equal to 15 % of the original width or height is
+random rotations up to ±10°, with exposed regions filled in gray (RGB 128).
+After the translation step, a gray (128,128,128) margin equal to 15 % of the
+original width or height is
 appended to the side opposite the shift along each axis. When `--top` or
 `--bottom` is supplied, the resulting image is further scaled to cover a
 512×512 frame and cropped so a reference band (20 % from the top when using

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ are left uncropped.
 
 In all modes the canvas experiences random translations up to ±10 pixels and
 random rotations up to ±10°, with exposed regions filled in gray. After the
-translation step, an additional 50 px gray margin is appended to the side
-opposite the shift on both axes. When `--top` or `--bottom` is supplied, the
-resulting image is further scaled to cover a 512×512 frame and cropped so a
-reference band (20 % from the top when using `--top`, 93 % when using `--bottom`)
+translation step, a gray margin equal to 15 % of the original width or height is
+appended to the side opposite the shift along each axis. When `--top` or
+`--bottom` is supplied, the resulting image is further scaled to cover a
+512×512 frame and cropped so a reference band (20 % from the top when using
+`--top`, 93 % when using `--bottom`)
 lands at the canvas center. Each processed file keeps the original base name and
 is written to the specified output directory. After running this preprocessing
 step you can proceed with the usual training command below.

--- a/preprocess_a.py
+++ b/preprocess_a.py
@@ -1,10 +1,11 @@
 import os
 import argparse
 import random
-import cv2
-import numpy as np
 
-def process_image(img_path, output_path, keep_bottom=False):
+def process_image(img_path, output_path, crop_mode=None):
+    import cv2
+    import numpy as np
+
     img = cv2.imread(img_path, cv2.IMREAD_COLOR)
     if img is None:
         print(f"Unable to read {img_path}")
@@ -12,8 +13,9 @@ def process_image(img_path, output_path, keep_bottom=False):
 
     h, w = img.shape[:2]
     gray_val = 127
+    gray = (gray_val, gray_val, gray_val)
 
-    if keep_bottom:
+    if crop_mode == "bottom":
         # keep the bottom 30% and fade between 65% and 75%
         mask = np.zeros((h, w), dtype=np.float32)
         mask[int(h * 0.7) :, :] = 1.0
@@ -22,7 +24,7 @@ def process_image(img_path, output_path, keep_bottom=False):
         mask[: int(h * 0.65), :] = 0.0
         mask[int(h * 0.75) :, :] = 1.0
         center_ratio = 0.93
-    else:
+    elif crop_mode == "top":
         # keep the top 40% and fade between 35% and 45%
         mask = np.zeros((h, w), dtype=np.float32)
         mask[: int(h * 0.4), :] = 1.0
@@ -31,9 +33,15 @@ def process_image(img_path, output_path, keep_bottom=False):
         mask[: int(h * 0.35), :] = 1.0
         mask[int(h * 0.45) :, :] = 0.0
         center_ratio = 0.2
-    gray_img = np.full_like(img, gray_val, dtype=np.uint8)
-    blended = img.astype(np.float32) * mask[:, :, None] + gray_img.astype(np.float32) * (1 - mask[:, :, None])
-    blended = blended.astype(np.uint8)
+    else:
+        mask = None
+
+    if mask is not None:
+        gray_img = np.full_like(img, gray_val, dtype=np.uint8)
+        blended = img.astype(np.float32) * mask[:, :, None] + gray_img.astype(np.float32) * (1 - mask[:, :, None])
+        blended = blended.astype(np.uint8)
+    else:
+        blended = img
 
     # compute padding so rotation/translation don't crop the image
     max_trans = 10
@@ -43,9 +51,8 @@ def process_image(img_path, output_path, keep_bottom=False):
     h_rot = h * abs(np.cos(rad)) + w * abs(np.sin(rad))
     pad_w = int(np.ceil((w_rot - w) / 2 + max_trans))
     pad_h = int(np.ceil((h_rot - h) / 2 + max_trans))
-    gray = (gray_val, gray_val, gray_val)
 
-    if keep_bottom:
+    if crop_mode == "bottom":
         top_pad = int(pad_h * 0.5)
         bottom_pad = int(pad_h * 1.5)
         side_pad = int(pad_w * 0.8)
@@ -68,10 +75,14 @@ def process_image(img_path, output_path, keep_bottom=False):
         padded, M, (pw, ph), borderMode=cv2.BORDER_CONSTANT, borderValue=gray
     )
 
+    if crop_mode is None:
+        cv2.imwrite(output_path, transformed)
+        return
+
     # scale to cover 512x512 and crop so a reference band sits at the canvas center
     target = 512
     scale = target / min(pw, ph)
-    if keep_bottom:
+    if crop_mode == "bottom":
         scale *= 1.1
     new_w = int(np.ceil(pw * scale))
     new_h = int(np.ceil(ph * scale))
@@ -83,26 +94,32 @@ def process_image(img_path, output_path, keep_bottom=False):
     crop = resized[y_off : y_off + target, x_off : x_off + target]
     cv2.imwrite(output_path, crop)
 
-def process_split(source_dir, dest_dir, keep_bottom=False):
+def process_dir(source_dir, dest_dir, crop_mode=None):
     os.makedirs(dest_dir, exist_ok=True)
     for fname in os.listdir(source_dir):
         if fname.lower().endswith((".jpg", ".jpeg", ".png", ".bmp")):
             src = os.path.join(source_dir, fname)
             base = os.path.splitext(fname)[0]
             dst = os.path.join(dest_dir, base + ".png")
-            process_image(src, dst, keep_bottom)
+            process_image(src, dst, crop_mode)
 
 def main():
-    parser = argparse.ArgumentParser(description="Preprocess domain A images.")
-    parser.add_argument("--dataset_name", required=True, help="Name of the dataset inside dataset/.")
-    parser.add_argument("--source_root", default="preprocess_source", help="Root directory containing raw images.")
-    parser.add_argument("--dataset_root", default="dataset", help="Root directory for processed dataset.")
-    parser.add_argument("--bottom", action="store_true", help="keep bottom 30% instead of top 40%")
+    parser = argparse.ArgumentParser(description="Preprocess images with optional cropping.")
+    parser.add_argument("--input_dir", required=True, help="Directory containing raw images.")
+    parser.add_argument("--output_dir", required=True, help="Directory to save processed images.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--top", action="store_true", help="keep top 40%% and fade between 35%% and 45%%")
+    group.add_argument("--bottom", action="store_true", help="keep bottom 30%% and fade between 65%% and 75%%")
     args = parser.parse_args()
-    for split in ["trainA", "testA"]:
-        src_dir = os.path.join(args.source_root, split)
-        dst_dir = os.path.join(args.dataset_root, args.dataset_name, split)
-        process_split(src_dir, dst_dir, args.bottom)
+
+    if args.bottom:
+        mode = "bottom"
+    elif args.top:
+        mode = "top"
+    else:
+        mode = None
+
+    process_dir(args.input_dir, args.output_dir, mode)
 
 if __name__ == "__main__":
     main()

--- a/preprocess_a.py
+++ b/preprocess_a.py
@@ -12,6 +12,8 @@ def process_image(img_path, output_path, crop_mode=None):
         return
 
     h, w = img.shape[:2]
+    extra_w = int(round(w * 0.15))
+    extra_h = int(round(h * 0.15))
     gray_val = 127
     gray = (gray_val, gray_val, gray_val)
 
@@ -75,10 +77,10 @@ def process_image(img_path, output_path, crop_mode=None):
         padded, M, (pw, ph), borderMode=cv2.BORDER_CONSTANT, borderValue=gray
     )
 
-    extra_left = 50 if tx > 0 else 0
-    extra_right = 50 if tx < 0 else 0
-    extra_top = 50 if ty < 0 else 0
-    extra_bottom = 50 if ty > 0 else 0
+    extra_left = extra_w if tx > 0 else 0
+    extra_right = extra_w if tx < 0 else 0
+    extra_top = extra_h if ty < 0 else 0
+    extra_bottom = extra_h if ty > 0 else 0
     if extra_left or extra_right or extra_top or extra_bottom:
         transformed = cv2.copyMakeBorder(
             transformed,

--- a/preprocess_a.py
+++ b/preprocess_a.py
@@ -14,7 +14,7 @@ def process_image(img_path, output_path, crop_mode=None):
     h, w = img.shape[:2]
     extra_w = int(round(w * 0.15))
     extra_h = int(round(h * 0.15))
-    gray_val = 127
+    gray_val = 128
     gray = (gray_val, gray_val, gray_val)
 
     if crop_mode == "bottom":


### PR DESCRIPTION
## Summary
- add `--top`/`--bottom` flags to control optional cropping
- CLI now uses explicit `--input_dir`/`--output_dir` instead of dataset-based arguments
- import heavy dependencies lazily so `--help` works without OpenCV/NumPy

## Testing
- `python -m py_compile preprocess_a.py`
- `python preprocess_a.py --help`
- `pip install numpy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b68ea6ce208322970bf6f058333a24