### PR TITLE
Add configurable forward noise for generator

### DIFF
--- a/UGATIT.py
+++ b/UGATIT.py
@@ -71,6 +71,7 @@ class UGATIT(object) :
         self.resume_iter = args.resume_iter
         self.use_checkpoint = args.use_checkpoint and _CHECKPOINT_AVAILABLE
         self.sigma_f = args.sigma_f
+        self.noise_blocks = args.noise_blocks
 
         if args.use_checkpoint and not _CHECKPOINT_AVAILABLE:
             print('WARNING: torch.utils.checkpoint is not available. Gradient checkpointing is disabled.')
@@ -110,6 +111,7 @@ class UGATIT(object) :
         print("# style_dim : ", self.style_dim)
         print("# ds_weight : ", self.ds_weight)
         print("# sigma_f : ", self.sigma_f)
+        print("# noise_blocks : ", self.noise_blocks)
 
 
 
@@ -171,11 +173,13 @@ class UGATIT(object) :
         self.genA2B = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
                                       light=self.light, style_dim=self.style_dim,
-                                      use_ds=self.use_ds, sigma_f=self.sigma_f).to(self.device)
+                                      use_ds=self.use_ds, sigma_f=self.sigma_f,
+                                      noise_blocks=self.noise_blocks).to(self.device)
         self.genB2A = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
                                       light=self.light, style_dim=self.style_dim,
-                                      use_ds=self.use_ds, sigma_f=self.sigma_f).to(self.device)
+                                      use_ds=self.use_ds, sigma_f=self.sigma_f,
+                                      noise_blocks=self.noise_blocks).to(self.device)
         self.disGA = Discriminator(input_nc=3, ndf=self.ch, n_layers=7).to(self.device)
         self.disGB = Discriminator(input_nc=3, ndf=self.ch, n_layers=7).to(self.device)
         self.disLA = Discriminator(input_nc=3, ndf=self.ch, n_layers=5).to(self.device)

--- a/UGATIT.py
+++ b/UGATIT.py
@@ -70,6 +70,7 @@ class UGATIT(object) :
         self.resume = args.resume
         self.resume_iter = args.resume_iter
         self.use_checkpoint = args.use_checkpoint and _CHECKPOINT_AVAILABLE
+        self.sigma_f = args.sigma_f
 
         if args.use_checkpoint and not _CHECKPOINT_AVAILABLE:
             print('WARNING: torch.utils.checkpoint is not available. Gradient checkpointing is disabled.')
@@ -108,6 +109,7 @@ class UGATIT(object) :
         print("# use_ds : ", self.use_ds)
         print("# style_dim : ", self.style_dim)
         print("# ds_weight : ", self.ds_weight)
+        print("# sigma_f : ", self.sigma_f)
 
 
 
@@ -169,11 +171,11 @@ class UGATIT(object) :
         self.genA2B = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
                                       light=self.light, style_dim=self.style_dim,
-                                      use_ds=self.use_ds).to(self.device)
+                                      use_ds=self.use_ds, sigma_f=self.sigma_f).to(self.device)
         self.genB2A = ResnetGenerator(input_nc=3, output_nc=3, ngf=self.ch, n_blocks=self.n_res,
                                       img_height=self.img_size, img_width=self.img_w,
                                       light=self.light, style_dim=self.style_dim,
-                                      use_ds=self.use_ds).to(self.device)
+                                      use_ds=self.use_ds, sigma_f=self.sigma_f).to(self.device)
         self.disGA = Discriminator(input_nc=3, ndf=self.ch, n_layers=7).to(self.device)
         self.disGB = Discriminator(input_nc=3, ndf=self.ch, n_layers=7).to(self.device)
         self.disLA = Discriminator(input_nc=3, ndf=self.ch, n_layers=5).to(self.device)

--- a/main.py
+++ b/main.py
@@ -55,6 +55,8 @@ def parse_args():
                         help='enable gradient checkpointing')
     parser.add_argument('--sigma_f', type=float, default=0.0,
                         help='Stddev of noise added before each upsampling block')
+    parser.add_argument('--noise_blocks', type=int, default=None,
+                        help='Number of early residual blocks to inject noise into')
 
     args = parser.parse_args()
     args.img_w = int(args.img_size * args.aspect_ratio)
@@ -85,6 +87,11 @@ def check_args(args):
         raise ValueError('img_size * aspect_ratio must be divisible by 4')
     if args.use_ds and args.style_dim <= 0:
         raise ValueError('style_dim must be positive when use_ds is enabled')
+    if args.noise_blocks is None:
+        args.noise_blocks = args.n_res - 1
+    else:
+        if not (0 <= args.noise_blocks <= args.n_res):
+            raise ValueError('noise_blocks must be between 0 and n_res')
     return args
 
 """main"""

--- a/main.py
+++ b/main.py
@@ -53,6 +53,8 @@ def parse_args():
                         help='The iteration of checkpoints to load for testing')
     parser.add_argument('--use_checkpoint', type=str2bool, default=False,
                         help='enable gradient checkpointing')
+    parser.add_argument('--sigma_f', type=float, default=0.0,
+                        help='Stddev of noise added before each upsampling block')
 
     args = parser.parse_args()
     args.img_w = int(args.img_size * args.aspect_ratio)

--- a/networks.py
+++ b/networks.py
@@ -6,7 +6,7 @@ from torch.nn.parameter import Parameter
 class ResnetGenerator(nn.Module):
     def __init__(self, input_nc, output_nc, ngf=64, n_blocks=6,
                  img_height=256, img_width=256, light=False,
-                 style_dim=8, use_ds=False):
+                 style_dim=8, use_ds=False, sigma_f=0.0):
         assert(n_blocks >= 0)
         super(ResnetGenerator, self).__init__()
         self.input_nc = input_nc
@@ -18,6 +18,7 @@ class ResnetGenerator(nn.Module):
         self.light = light
         self.style_dim = style_dim
         self.use_ds = use_ds
+        self.sigma_f = sigma_f
 
         DownBlock = []
         DownBlock += [nn.ReflectionPad2d(3),
@@ -123,6 +124,8 @@ class ResnetGenerator(nn.Module):
 
 
         for i in range(self.n_blocks):
+            if self.sigma_f != 0:
+                x = x + torch.randn_like(x) * self.sigma_f
             x = getattr(self, 'UpBlock1_' + str(i+1))(x, gamma, beta)
         out = self.UpBlock2(x)
 

--- a/networks.py
+++ b/networks.py
@@ -6,7 +6,8 @@ from torch.nn.parameter import Parameter
 class ResnetGenerator(nn.Module):
     def __init__(self, input_nc, output_nc, ngf=64, n_blocks=6,
                  img_height=256, img_width=256, light=False,
-                 style_dim=8, use_ds=False, sigma_f=0.0):
+                 style_dim=8, use_ds=False, sigma_f=0.0,
+                 noise_blocks=None):
         assert(n_blocks >= 0)
         super(ResnetGenerator, self).__init__()
         self.input_nc = input_nc
@@ -19,6 +20,7 @@ class ResnetGenerator(nn.Module):
         self.style_dim = style_dim
         self.use_ds = use_ds
         self.sigma_f = sigma_f
+        self.noise_blocks = n_blocks - 1 if noise_blocks is None else max(0, min(noise_blocks, n_blocks))
 
         DownBlock = []
         DownBlock += [nn.ReflectionPad2d(3),
@@ -124,7 +126,7 @@ class ResnetGenerator(nn.Module):
 
 
         for i in range(self.n_blocks):
-            if self.sigma_f != 0:
+            if self.sigma_f != 0 and i < self.noise_blocks:
                 x = x + torch.randn_like(x) * self.sigma_f
             x = getattr(self, 'UpBlock1_' + str(i+1))(x, gamma, beta)
         out = self.UpBlock2(x)


### PR DESCRIPTION
## Summary
- Add `sigma_f` parameter to `ResnetGenerator` to inject Gaussian noise before each upsampling block
- Expose `sigma_f` via command-line option and propagate through UGATIT model construction

## Testing
- `python -m py_compile networks.py UGATIT.py main.py`
- `python main.py --dataset selfie2anime --iteration 1 --batch_size 1 --sigma_f 0.1 --phase train` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68b8eb4e0b588322a85547973a77103e